### PR TITLE
Add support for loopback native email functionality

### DIFF
--- a/lib/sparkpost.js
+++ b/lib/sparkpost.js
@@ -88,6 +88,12 @@ Mailer.getTransmissionBody = function(options) {
     options = _.clone(options);
   }
 
+  options = _.mapValues(options, (val, key) => {
+    if (typeof val === 'function') return undefined;
+    if (val.toJSON) return val.toJSON();
+    return val;
+  });
+
   if (_.isString(options.to)) {
     options.to = options.to.split(',');
 

--- a/lib/sparkpost.js
+++ b/lib/sparkpost.js
@@ -90,7 +90,7 @@ Mailer.getTransmissionBody = function(options) {
 
   options = _.mapValues(options, (val, key) => {
     if (typeof val === 'function') return undefined;
-    if (val.toJSON) return val.toJSON();
+    if (val && val.toJSON) return val.toJSON();
     return val;
   });
 

--- a/package.json
+++ b/package.json
@@ -46,13 +46,13 @@
   "dependencies": {
     "lodash": "^2.4.1",
     "q": "^1.0.1",
-    "sparkpost": "^1.3.3"
+    "sparkpost": "^2.1.2"
   },
   "description": "Loopback connector module which allow to send emails via Sparkpost",
   "devDependencies": {
     "chai": "^1.9.2",
-    "loopback": "^2.7.0",
-    "loopback-datasource-juggler": "^2.10.2",
+    "loopback": "^3.11.1",
+    "loopback-datasource-juggler": "^3.12.0",
     "mocha": "^2.0.1",
     "rewire": "^2.1.2"
   },
@@ -84,6 +84,8 @@
     "type": "git",
     "url": "git+https://github.com/nidhhoggr/loopback-connector-sparkpost.git"
   },
-  "scripts": {},
+  "scripts": {
+    "test": "node ./node_modules/.bin/mocha"
+  },
   "version": "0.0.5"
 }

--- a/package.json
+++ b/package.json
@@ -46,14 +46,15 @@
   "dependencies": {
     "lodash": "^2.4.1",
     "q": "^1.0.1",
+    "sinon": "^4.0.2",
     "sparkpost": "^2.1.2"
   },
   "description": "Loopback connector module which allow to send emails via Sparkpost",
   "devDependencies": {
     "chai": "^1.9.2",
-    "loopback": "^3.11.1",
+    "loopback": "^3.16.0",
     "loopback-datasource-juggler": "^3.12.0",
-    "mocha": "^2.0.1",
+    "mocha": "^4.0.1",
     "rewire": "^2.1.2"
   },
   "directories": {},
@@ -85,7 +86,7 @@
     "url": "git+https://github.com/nidhhoggr/loopback-connector-sparkpost.git"
   },
   "scripts": {
-    "test": "node ./node_modules/.bin/mocha"
+    "test": "node ./node_modules/.bin/mocha --inspect"
   },
   "version": "0.0.5"
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,14 +1,18 @@
-require('./helpers/init.js');
+require("./helpers/init.js");
 
-var loopback = require('loopback'),
-    rewire = require("rewire"),
-    Connector = rewire('../lib/sparkpost'),
-    DataSource = require('loopback-datasource-juggler').DataSource,
-    Email, User, ds;
+var loopback = require("loopback"),
+  rewire = require("rewire"),
+  sinon = require("sinon"),
+  sparkpost = require("sparkpost"),
+  Connector = rewire("../lib/sparkpost"),
+  DataSource = require("loopback-datasource-juggler").DataSource,
+  Email,
+  User,
+  ds;
 
-var apiKey = process.env.apiKey;
+var apiKey = process.env.apiKey || "apiKey";
 
-var fromEmail = process.env.fromEmail;
+var fromEmail = process.env.fromEmail || "fromEmail";
 
 var __SparkpostMock__ = {
   Sparkpost: function(apiKey) {
@@ -16,151 +20,152 @@ var __SparkpostMock__ = {
       apiKey: apiKey,
       messages: {
         send: function(options, success, error) {
-          success([{
-            email: options.message.to[0].email,
-            status: 'sent',
-            _id: 'someidofmessage'
-          }]);
+          success([
+            {
+              email: options.message.to[0].email,
+              status: "sent",
+              _id: "someidofmessage"
+            }
+          ]);
         }
       }
-    }
+    };
   }
-}
+};
 
-describe('Sparkpost init', function () {
-  it('should throw error ', function () {
-    expect(function() { new Connector(); }).to.throw();
+describe("Basic Test", function() {
+
+  before(function() {
+    sinon.stub(sparkpost.prototype, 'request').callsFake((options, callback) => {
+      callback(null, {statusCode: 200, data: {}});
+    });
+  });
+  describe("Sparkpost init", function() {
+    it("should throw error ", function() {
+      expect(function() {
+        new Connector();
+      }).to.throw();
+    });
+
+    it("should have property sparkpost with api key", function() {
+      connector = new Connector({ apiKey: apiKey });
+      expect(connector).to.have.a.property("sparkpost");
+      expect(connector.sparkpost.apiKey).to.equal(apiKey);
+    });
+
+    it("should have property sparkpost with api key", function() {
+      connector = new Connector({ apiKey: apiKey });
+      expect(connector).to.have.a.property("sparkpost");
+      expect(connector.sparkpost.apiKey).to.equal(apiKey);
+    });
   });
 
-  it('should have property sparkpost with api key', function () {
-    connector = new Connector({ apiKey: apiKey });
-    expect(connector).to.have.a.property('sparkpost');
-    expect(connector.sparkpost.apiKey).to.equal(apiKey);
-  });
-
-  it('should have property sparkpost with api key', function () {
-    connector = new Connector({ apiKey: apiKey });
-    expect(connector).to.have.a.property('sparkpost');
-    expect(connector.sparkpost.apiKey).to.equal(apiKey);
-  });
-});
-
-describe('Sparkpost message send', function() {
-
-  beforeEach(function() {
-    Connector.__set__('Sparkpost', __SparkpostMock__);
-    ds = new DataSource({
-      connector: Connector,
-      apiKey: apiKey,
-      defaults: {
-        options: {
-          start_time: process.env.startTime || 'now',
-          open_tracking: false,
-          click_tracking: false
+  describe("Sparkpost message send", function() {
+    beforeEach(function() {
+      Connector.__set__("Sparkpost", __SparkpostMock__);
+      ds = new DataSource({
+        connector: Connector,
+        apiKey: apiKey,
+        defaults: {
+          options: {
+            start_time: process.env.startTime || "now",
+            open_tracking: false,
+            click_tracking: false
+          }
         }
-      }
+      });
+      let mem = new DataSource({
+        connector: 'memory'
+      });
+
+      User = loopback.User.extend("testUser");
+      User.attachTo(mem);
+      Email = loopback.Email.extend("testEmail");
+      Email.attachTo(ds);
     });
 
-    Email = loopback.Email.extend('testEmail');
-    Email.attachTo(ds);
-  });
-
-  it('should contain the correct properties', function() {
-
-    var options = {
-      "to": 'sparkpost.connector.testing@mailinator.com',
-      "from": fromEmail,
-      "type": "email",
-      "content": {
-        "subject": "Thanks for registering.",
-        "template": {
-          "id": "greenback-verify-email"
-        }
-      },
-      "options": {
-        "start_time": new Date(new Date().getTime() + 30 * 60000).toISOString().slice(0, -5)
-      }
-    }
-
-    var transmissionBody = Email.getTransmissionBody(options);
-    expect(transmissionBody.options.start_time).to.equal(options.options.start_time);
-    expect(transmissionBody.options.click_tracking).to.equal(false);
-    expect(transmissionBody.options.open_tracking).to.equal(false);
-  });
-
-  it('Should send - Email.send', function(done) {
-    var msg = {
-      from: fromEmail,
-      to: 'sparkpost.connector.testing@mailinator.com',
-      subject: 'Test subject',
-      text: 'Plain text',
-      html: 'Html <b>content</b>'
-    };
-
-    Email.send(msg, function(err, result) {
-      expect(err).to.equal(null);
-      expect(result.statusCode).to.equal(200);
-      done();
-    });
-  });
-
-  it('Should send - Email.prototype.send', function(done) {
-    var msg = {
-      from: fromEmail,
-      to: 'sparkpost.connector.testing@mailinator.com',
-      subject: 'Test subject',
-      text: 'Plain text',
-      html: 'Html <b>content</b>'
-    };
-
-    var email = new Email(msg);
-
-    email.send(function(err, result) {
-      expect(err).to.equal(null);
-      expect(result.statusCode).to.equal(200);
-      done();
-    });
-  });
-
-});
-
-describe('Sparkpost verify loopback user', function() {
-
-  beforeEach(function() {
-    User = loopback.User.extend('testUser');
-    var mem = new DataSource({
-      connector: 'memory'
-    });
-    User.attachTo(mem);
-    var mail = new DataSource({
-      connector: 'sparkpost',
-      apiKey: apiKey,
-      defaults: {
-        options: {
-          start_time: process.env.startTime || 'now',
-          open_tracking: false,
-          click_tracking: false
-        }
-      }
-    });
-    Email.attachTo(mail);
-  });
-
-  it('should verify a user and send an email', function(done) {
-    User.create({email: 'mock-user@example.com', password: 'password'}, (err, user) => {
+    it("should contain the correct properties", function() {
       var options = {
-        type: 'email',
-        to: user.email,
+        to: "sparkpost.connector.testing@mailinator.com",
         from: fromEmail,
-        subject: 'Thanks for registering.',
-        user: user
+        type: "email",
+        content: {
+          subject: "Thanks for registering.",
+          template: {
+            id: "greenback-verify-email"
+          }
+        },
+        options: {
+          start_time: new Date(new Date().getTime() + 30 * 60000)
+            .toISOString()
+            .slice(0, -5)
+        }
       };
-      user.verify(options, (err, response) => {
-        console.log(err);
-        console.log(response);
+
+      var transmissionBody = Email.getTransmissionBody(options);
+      expect(transmissionBody.options.start_time).to.equal(
+        options.options.start_time
+      );
+      expect(transmissionBody.options.click_tracking).to.equal(false);
+      expect(transmissionBody.options.open_tracking).to.equal(false);
+    });
+
+    it("Should send - Email.send", function(done) {
+      var msg = {
+        from: fromEmail,
+        to: "sparkpost.connector.testing@mailinator.com",
+        subject: "Test subject",
+        text: "Plain text",
+        html: "Html <b>content</b>"
+      };
+      Email.send(msg, (err, data) => {
+        done(err);
+      });
+    });
+
+    it("Should send - Email.prototype.send", function(done) {
+      var msg = {
+        from: fromEmail,
+        to: "sparkpost.connector.testing@mailinator.com",
+        subject: "Test subject",
+        text: "Plain text",
+        html: "Html <b>content</b>"
+      };
+
+      var email = new Email(msg);
+
+      email.send((err, result) => {
+        expect(err).to.equal(null);
+        expect(result.statusCode).to.equal(200);
         done();
       });
     });
-  });
 
+    describe("Sparkpost verify loopback user", function() {
+      beforeEach(function() {
+        process.env.SPARKPOST_API_KEY = 'abckey';
+      });
+
+      it("should verify a user and send an email", function(done) {
+        User.create(
+          { email: "mock-user@example.com", password: "password" },
+          (err, user) => {
+            var options = {
+              type: "email",
+              mailer: Email,
+              to: user.email,
+              from: fromEmail,
+              subject: "Thanks for registering.",
+              user: user
+            };
+            user.verify(options, (err, response) => {
+              expect(response.email.statusCode).to.equal(200);
+              expect(response.token).to.exist;
+              done(err);
+            });
+          }
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
Out of the box, loopback provides a way to [verify users via email](https://loopback.io/doc/en/lb3/Registering-users.html#verifying-email-addresses), this pull request adds handling for sending loopback models into the connector.

Have also modified the tests to stub out the requests to sparkpost using [sinon](https://www.npmjs.com/package/sinon).

Fixes issue #2.