### PR TITLE
Promote transmissionBody to the first argument to align with API 2.0

### DIFF
--- a/lib/sparkpost.js
+++ b/lib/sparkpost.js
@@ -158,7 +158,7 @@ Mailer.send = function (options, cb) {
 
     var transmissionBody = this.getTransmissionBody(options);
 
-    connector.sparkpost.transmissions.send({transmissionBody: transmissionBody}, function(err, res) {
+    connector.sparkpost.transmissions.send(transmissionBody, function(err, res) {
       if (err) {
         fn(err, null);
       } else {


### PR DESCRIPTION
This pull request resolves issue #4.

The contents of the `transmissionBody` property have been promoted to the body root as noted in the [Sparkpost API 2.0 update post](https://www.sparkpost.com/blog/sparkpost-node-js-client-library/).